### PR TITLE
Solved error

### DIFF
--- a/polling_irq_c/CMakeLists.txt
+++ b/polling_irq_c/CMakeLists.txt
@@ -26,7 +26,7 @@ target_include_directories(signal_polling_irq PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
 target_link_libraries(signal_polling_irq 
 	pico_stdlib 
 	hardware_timer
-	pico_cyw43_arch_none 
+	# pico_cyw43_arch_none 
 	hardware_gpio 
 	hardware_pwm 
 	hardware_irq 

--- a/polling_irq_c/functs.c
+++ b/polling_irq_c/functs.c
@@ -12,7 +12,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdio.h>
-#include "pico/cyw43_arch.h"
+// #include "pico/cyw43_arch.h"
 #include "pico/stdlib.h"
 #include "pico/time.h"
 #include "hardware/timer.h"


### PR DESCRIPTION
The error: /fix opening dependency file CMakeFiles\signal_polling_irq.dir\6884bd2ac5927ab668ff9a833dcb71bf\async_context_threadsafe_background.c.obj.d: No such file or directory
that appeared was solved.